### PR TITLE
[PR] If a post date is not passed, use the current time.

### DIFF
--- a/wsuwp-content-syndicate.php
+++ b/wsuwp-content-syndicate.php
@@ -119,7 +119,12 @@ class WSU_Content_Syndicate {
 					$subset->thubmnail = false;
 				}
 
-				$subset_key = strtotime( $post->date );
+				if ( $post->date ) {
+					$subset_key = strtotime( $post->date );
+				} else {
+					$subset_key = time();
+				}
+
 				while ( array_key_exists( $subset_key, $new_data ) ) {
 					$subset_key++;
 				}


### PR DESCRIPTION
This is a horrible work around, but it appears that we can not
yet rely on the post date being passed with the JSON response.