### PR TITLE
[PR] Don't reverse sort by date when pulling events.

### DIFF
--- a/wsuwp-content-syndicate.php
+++ b/wsuwp-content-syndicate.php
@@ -337,9 +337,6 @@ class WSU_Content_Syndicate {
 			}
 		}
 
-		// Reverse sort the array of data by date.
-		krsort( $new_data );
-
 		ob_start();
 		if ( 'headlines' === $atts['output'] ) {
 			?>


### PR DESCRIPTION
I'm not sure if this will break something, but it's super confusing that I had it there in the first place and is causing events to show up in a strange order when embedded on other sites.