### PR TITLE
[PR] Support a full site URL with path rather than only bare hosts

### DIFF
--- a/wsuwp-content-syndicate.php
+++ b/wsuwp-content-syndicate.php
@@ -55,6 +55,8 @@ class WSU_Content_Syndicate {
 			$site_url = parse_url( esc_url( $atts['host'] ) );
 		}
 
+		$site_url['path'] = trailingslashit( $site_url['path'] );
+
 		if ( empty( $site_url['host'] ) ) {
 			return '<!-- wsuwp_json ERROR - an empty host was supplied -->';
 		}

--- a/wsuwp-content-syndicate.php
+++ b/wsuwp-content-syndicate.php
@@ -50,12 +50,12 @@ class WSU_Content_Syndicate {
 
 		// If a site attribute is provided, it overrides the host attribute.
 		if ( ! empty( $atts['site'] ) ) {
-			$site_url = parse_url( esc_url( $atts['site'] ) );
+			$site_url = trailingslashit( esc_url( $atts['site'] ) );
 		} else {
-			$site_url = parse_url( esc_url( $atts['host'] ) );
+			$site_url = trailingslashit( esc_url( $atts['host'] ) );
 		}
 
-		$site_url['path'] = trailingslashit( $site_url['path'] );
+		$site_url = parse_url( $site_url );
 
 		if ( empty( $site_url['host'] ) ) {
 			return '<!-- wsuwp_json ERROR - an empty host was supplied -->';

--- a/wsuwp-content-syndicate.php
+++ b/wsuwp-content-syndicate.php
@@ -30,6 +30,7 @@ class WSU_Content_Syndicate {
 			'object' => 'json_data',
 			'output' => 'json', // Can also be headlines, excerpts, or full
 			'host' => 'news.wsu.edu',
+			'site' => '',
 			'university_category_slug' => '',
 			'site_category_slug' => '',
 			'tag' => '',
@@ -47,17 +48,23 @@ class WSU_Content_Syndicate {
 			return '<!-- wsuwp_json ERROR - query not supported -->';
 		}
 
-		// We only support queries for wsu.edu domains by default
-		$host = parse_url( esc_url( $atts['host'] ) );
-		if ( empty( $host['host'] ) ) {
+		// If a site attribute is provided, it overrides the host attribute.
+		if ( ! empty( $atts['site'] ) ) {
+			$site_url = parse_url( esc_url( $atts['site'] ) );
+		} else {
+			$site_url = parse_url( esc_url( $atts['host'] ) );
+		}
+
+		if ( empty( $site_url['host'] ) ) {
 			return '<!-- wsuwp_json ERROR - an empty host was supplied -->';
 		}
 
-		$host_parts = explode( '.', $host['host'] );
+		$host_parts = explode( '.', $site_url['host'] );
 		$host_edu = array_pop( $host_parts );
 		$host_wsu = array_pop( $host_parts );
 
-		if ( ( 'edu' !== $host_edu || 'wsu' !== $host_wsu ) && false === apply_filters( 'wsu_consyn_valid_domain', false, $host['host'] ) ) {
+		// We only support queries for wsu.edu domains by default
+		if ( ( 'edu' !== $host_edu || 'wsu' !== $host_wsu ) && false === apply_filters( 'wsu_consyn_valid_domain', false, $site_url['host'] ) ) {
 			return '<!-- wsuwp_json ERROR - not a valid domain -->';
 		}
 
@@ -67,7 +74,7 @@ class WSU_Content_Syndicate {
 			return apply_filters( 'wsuwp_content_syndicate_json', $content, $atts );
 		}
 
-		$request_url = esc_url( $host['host'] . '/wp-json/' ) . $atts['query'];
+		$request_url = esc_url( $site_url['host'] . $site_url['path'] . 'wp-json/' ) . $atts['query'];
 
 		if ( ! empty( $atts['university_category_slug'] ) ) {
 			$request_url = add_query_arg( array(

--- a/wsuwp-content-syndicate.php
+++ b/wsuwp-content-syndicate.php
@@ -270,6 +270,7 @@ class WSU_Content_Syndicate {
 		$defaults = array(
 			'output' => 'headlines', // Can also be sidebar, full
 			'host' => 'calendar.wsu.edu',
+			'site' => '',
 			'tag' => '',
 			'category' => '',
 			'query' => 'posts/?type=tribe_events',
@@ -279,17 +280,24 @@ class WSU_Content_Syndicate {
 		);
 		$atts = shortcode_atts( $defaults, $atts );
 
-		// We only support queries for wsu.edu domains by default
-		$host = parse_url( esc_url( $atts['host'] ) );
-		if ( empty( $host['host'] ) ) {
+		if ( ! empty( $atts['site'] ) ) {
+			$site_url = trailingslashit( esc_url( $atts['site'] ) );
+		} else {
+			$site_url = trailingslashit( esc_url( $atts['host'] ) );
+		}
+
+		$site_url = parse_url( $site_url );
+
+		if ( empty( $site_url['host'] ) ) {
 			return '<!-- wsuwp_json ERROR - an empty host was supplied -->';
 		}
 
-		$host_parts = explode( '.', $host['host'] );
+		$host_parts = explode( '.', $site_url['host'] );
 		$host_edu = array_pop( $host_parts );
 		$host_wsu = array_pop( $host_parts );
 
-		if ( ( ! in_array( $host_edu, array( 'edu', 'dev' ) ) || 'wsu' !== $host_wsu ) && false === apply_filters( 'wsu_consyn_valid_domain', false, $host['host'] ) ) {
+		// We only support queries for wsu.edu domains by default
+		if ( ( ! in_array( $host_edu, array( 'edu', 'dev' ) ) || 'wsu' !== $host_wsu ) && false === apply_filters( 'wsu_consyn_valid_domain', false, $site_url['host'] ) ) {
 			return '<!-- wsuwp_json ERROR - not a valid domain -->';
 		}
 
@@ -309,7 +317,7 @@ class WSU_Content_Syndicate {
 			}
 		}
 
-		$request_url = esc_url( $host['host'] . '/wp-json/' ) . $atts['query'];
+		$request_url = esc_url( $site_url['host'] . $site_url['path'] . 'wp-json/' ) . $atts['query'];
 
 		if ( ! empty( $atts['tag'] ) ) {
 			$request_url = add_query_arg( array( 'filter[tag]' => sanitize_key( $atts['tag'] ) ), $request_url );


### PR DESCRIPTION
Adds a `site` attribute to be used for specifying a full URL when a hostname does not suffice.

Fixes #22