### PR TITLE
[PR] If a count is not specified, don't limit the count

### DIFF
--- a/wsuwp-content-syndicate.php
+++ b/wsuwp-content-syndicate.php
@@ -179,7 +179,9 @@ class WSU_Content_Syndicate {
 
 		// Only provide a count to match the total count, the array may be larger if local
 		// items are also requested.
-		$new_data = array_slice( $new_data, 0, $atts['count'], false );
+		if ( $atts['count'] ) {
+			$new_data = array_slice( $new_data, 0, $atts['count'], false );
+		}
 
 		ob_start();
 		// By default, we output a JSON object that can then be used by a script.


### PR DESCRIPTION
Previously, if a count was not specified, the default of false
would create a situation where no items would be shown. We should
instead fall back to the number of items offered by the requested
site.