### PR TITLE
[PR] Implement previously suggested changes from CAHNRS

### DIFF
--- a/includes/syndicate-shortcode-base.php
+++ b/includes/syndicate-shortcode-base.php
@@ -86,7 +86,7 @@ class WSU_Syndicate_Shortcode_Base {
 		$defaults = shortcode_atts( $this->defaults_atts, $this->local_default_atts );
 		$defaults = $defaults + $this->local_extended_atts;
 
-		return shortcode_atts( $defaults, $atts );
+		return shortcode_atts( $defaults, $atts, $this->shortcode_name );
 	}
 
 	/**

--- a/includes/syndicate-shortcode-base.php
+++ b/includes/syndicate-shortcode-base.php
@@ -25,6 +25,7 @@ class WSU_Syndicate_Shortcode_Base {
 		'site' => '',
 		'university_category_slug' => '',
 		'university_organization_slug' => '',
+		'university_location_slug' => '',
 		'site_category_slug' => '',
 		'tag' => '',
 		'query' => 'posts',
@@ -163,6 +164,13 @@ class WSU_Syndicate_Shortcode_Base {
 			$request_url = add_query_arg( array(
 				'filter[taxonomy]' => 'wsuwp_university_org',
 				'filter[term]' => sanitize_key( $atts['university_organization_slug'] ),
+			), $request_url );
+		}
+
+		if ( ! empty( $atts['university_location_slug'] ) ) {
+			$request_url = add_query_arg( array(
+				'filter[taxonomy]' => 'wsuwp_university_location',
+				'filter[term]' => sanitize_key( $atts['university_location_slug'] ),
 			), $request_url );
 		}
 

--- a/includes/syndicate-shortcode-base.php
+++ b/includes/syndicate-shortcode-base.php
@@ -52,6 +52,11 @@ class WSU_Syndicate_Shortcode_Base {
 	public $local_extended_atts = array();
 
 	/**
+	 * @var string The shortcode name.
+	 */
+	public $shortcode_name = '';
+
+	/**
 	 * A common constructor that initiates the shortcode.
 	 */
 	public function construct() {

--- a/includes/syndicate-shortcode-events.php
+++ b/includes/syndicate-shortcode-events.php
@@ -18,6 +18,11 @@ class WSU_Syndicate_Shortcode_Events extends WSU_Syndicate_Shortcode_Base {
 		'category' => '',
 	);
 
+	/**
+	 * @var string Shortcode name.
+	 */
+	public $shortcode_name = 'wsuwp_events';
+
 	public function __construct() {
 		parent::construct();
 	}

--- a/includes/syndicate-shortcode-json.php
+++ b/includes/syndicate-shortcode-json.php
@@ -1,6 +1,12 @@
 <?php
 
 class WSU_Syndicate_Shortcode_JSON extends WSU_Syndicate_Shortcode_Base {
+
+	/**
+	 * @var string Shortcode name.
+	 */
+	public $shortcode_name = 'wsuwp_json';
+
 	public function __construct() {
 		parent::construct();
 	}

--- a/includes/syndicate-shortcode-people.php
+++ b/includes/syndicate-shortcode-people.php
@@ -11,6 +11,11 @@ class WSU_Syndicate_Shortcode_People extends WSU_Syndicate_Shortcode_Base {
 		'query'  => 'people',
 	);
 
+	/**
+	 * @var string Shortcode name.
+	 */
+	public $shortcode_name = 'wsuwp_people';
+
 	public function __construct() {
 		parent::construct();
 	}

--- a/includes/syndicate-shortcode-people.php
+++ b/includes/syndicate-shortcode-people.php
@@ -61,7 +61,7 @@ class WSU_Syndicate_Shortcode_People extends WSU_Syndicate_Shortcode_Base {
 
 		$people = json_decode( $data );
 
-		$people = apply_filters( 'wsuwp_people_sort_items', $people );
+		$people = apply_filters( 'wsuwp_people_sort_items', $people, $atts );
 
 		foreach ( $people as $person ) {
 			$content .= $this->generate_item_html( $person, $atts['output'] );


### PR DESCRIPTION
#41 from @philcable got lost a bit during the transition to the new WP-API. I'm going to cherry-pick some commits from that branch and apply them to master.

* Provide support for university location in all shortcodes with `university_location_slug` attribute.
* Pass `$atts` as additional context to `wsuwp_people_sort_items` filter.
* Include the shorcode name as a third parameter of `shortcode_atts()` to allow for use of the `shortcode_atts_{$shortcode}` filter.

There are two other commits I'm going to open in another PR for some continued discussion.