### PR TITLE
[PR] Remove line break inside `content-item-thumbnail`

### DIFF
--- a/includes/syndicate-shortcode-json.php
+++ b/includes/syndicate-shortcode-json.php
@@ -248,8 +248,7 @@ class WSU_Syndicate_Shortcode_JSON extends WSU_Syndicate_Shortcode_Base {
 						}
 						?>
 						<li class="wsuwp-content-syndicate-item">
-							<span class="content-item-thumbnail">
-								<?php if ( $content->thumbnail ) : ?><img src="<?php echo $content->thumbnail; ?>"><?php endif; ?></span>
+							<span class="content-item-thumbnail"><?php if ( $content->thumbnail ) : ?><img src="<?php echo $content->thumbnail; ?>"><?php endif; ?></span>
 							<span class="content-item-title"><a href="<?php echo $content->link; ?>"><?php echo $content->title; ?></a></span>
 							<span class="content-item-byline">
 								<span class="content-item-byline-date"><?php echo date( $atts['date_format'], strtotime( $content->date ) ); ?></span>


### PR DESCRIPTION
Primarily for styling purposes on the IP site news feed, but also for consistency. @jeremyfelt #reviewmerge?