### PR TITLE
[PR] Support explicit "remote" requests

### DIFF
--- a/includes/syndicate-shortcode-base.php
+++ b/includes/syndicate-shortcode-base.php
@@ -126,6 +126,60 @@ class WSU_Syndicate_Shortcode_Base {
 	}
 
 	/**
+	 * Process a given site URL and shortcode attributes into data to be used for the
+	 * request.
+	 *
+	 * If "http" or "https" is provided as scheme, then assume a remote request. If anything else
+	 * is passed ("local" by default), then verify the site is local and switch back to HTTP if
+	 * it is not.
+	 *
+	 * @since 0.10.0
+	 *
+	 * @param array $site_url Contains host and path of the requested URL.
+	 * @param array $atts     Contains the original shortcode attributes.
+	 *
+	 * @return array List of request information.
+	 */
+	public function build_initial_request( $site_url, $atts ) {
+		$url_scheme = 'http';
+		$local_site_id = false;
+
+		if ( in_array( $atts['scheme'], array( 'http', 'https' ) ) ) {
+			$url_scheme = $atts['scheme'];
+		} elseif ( is_multisite() ) {
+			$local_site = get_blog_details( array( 'domain' => $site_url['host'], 'path' => $site_url['path'] ), false );
+
+			if ( $local_site ) {
+				$local_site_id = $local_site->blog_id;
+				$local_home_url = get_home_url( $local_site_id );
+				$url_scheme = parse_url( $local_home_url, PHP_URL_SCHEME );
+			} else {
+				$atts['scheme'] = 'http';
+			}
+		} else {
+			$home_url_data = parse_url( get_home_url() );
+			$url_scheme = $home_url_data['scheme'];
+
+			if ( $home_url_data['host'] === $site_url['host'] && $home_url_data['path'] === $site_url['path'] ) {
+				$local_site_id = 1;
+				$atts['scheme'] = 'local';
+			} else {
+				$atts['scheme'] = $url_scheme;
+			}
+		}
+
+		$request_url = esc_url( $url_scheme . '://' . $site_url['host'] . $site_url['path'] . $this->default_path ) . $atts['query'];
+
+		$request = array(
+			'url' => $request_url,
+			'scheme' => $atts['scheme'],
+			'site_id' => $local_site_id,
+		);
+
+		return $request;
+	}
+
+	/**
 	 * Determine what the base URL should be used for REST API data.
 	 *
 	 * @param array $atts List of attributes used for the shortcode.

--- a/includes/syndicate-shortcode-json.php
+++ b/includes/syndicate-shortcode-json.php
@@ -62,9 +62,6 @@ class WSU_Syndicate_Shortcode_JSON extends WSU_Syndicate_Shortcode_Base {
 		}
 
 		$request = $this->build_initial_request( $site_url, $atts );
-		$request_scheme = $request['scheme'];
-		$local_site_id = $request['site_id'];
-
 		$request_url = $this->build_taxonomy_filters( $atts, $request['url'] );
 
 		if ( ! empty( $atts['offset'] ) ) {
@@ -78,9 +75,9 @@ class WSU_Syndicate_Shortcode_JSON extends WSU_Syndicate_Shortcode_Base {
 		$request_url = add_query_arg( array( '_embed' => '' ), $request_url );
 		$new_data = array();
 
-		if ( 'local' === $request_scheme ) {
+		if ( 'local' === $request['scheme'] ) {
 			if ( is_multisite() ) {
-				switch_to_blog( $local_site_id );
+				switch_to_blog( $request['site_id'] );
 			}
 
 			$request = WP_REST_Request::from_url( $request_url );

--- a/includes/syndicate-shortcode-json.php
+++ b/includes/syndicate-shortcode-json.php
@@ -61,32 +61,11 @@ class WSU_Syndicate_Shortcode_JSON extends WSU_Syndicate_Shortcode_Base {
 			return apply_filters( 'wsuwp_content_syndicate_json', $content, $atts );
 		}
 
-		$url_scheme = 'http';
-		$local_site_id = false;
-		// If local results were requested, verify the site is local first and switch back to HTTP if
-		// it is not. If remote results were requested, and this is multisite, check for a local site anyway.
-		if ( 'local' === $atts['scheme'] ) {
-			$local_site = get_blog_details( array( 'domain' => $site_url['host'], 'path' => $site_url['path'] ), false );
-			if ( $local_site ) {
-				$local_site_id = $local_site->blog_id;
-				$local_home_url = get_home_url( $local_site_id );
-				$url_scheme = parse_url( $local_home_url, PHP_URL_SCHEME );
-			} else {
-				$atts['scheme'] = 'http';
-			}
-		} elseif( is_multisite() ) {
-			$local_site = get_blog_details( array( 'domain' => $site_url['host'], 'path' => $site_url['path'] ), false );
-			if ( $local_site ) {
-				$local_site_id = $local_site->blog_id;
-				$local_home_url = get_home_url( $local_site_id );
-				$url_scheme = parse_url( $local_home_url, PHP_URL_SCHEME );
-				$atts['scheme'] = 'local';
-			}
-		}
+		$request = $this->build_initial_request( $site_url, $atts );
+		$request_scheme = $request['scheme'];
+		$local_site_id = $request['site_id'];
 
-		$request_url = esc_url( $url_scheme . '://' . $site_url['host'] . $site_url['path'] . $this->default_path ) . $atts['query'];
-
-		$request_url = $this->build_taxonomy_filters( $atts, $request_url );
+		$request_url = $this->build_taxonomy_filters( $atts, $request['url'] );
 
 		if ( ! empty( $atts['offset'] ) ) {
 			$atts['count'] = absint( $atts['count'] ) + absint( $atts['offset'] );
@@ -99,8 +78,11 @@ class WSU_Syndicate_Shortcode_JSON extends WSU_Syndicate_Shortcode_Base {
 		$request_url = add_query_arg( array( '_embed' => '' ), $request_url );
 		$new_data = array();
 
-		if ( 'local' === $atts['scheme'] ) {
-			switch_to_blog( $local_site_id );
+		if ( 'local' === $request_scheme ) {
+			if ( is_multisite() ) {
+				switch_to_blog( $local_site_id );
+			}
+
 			$request = WP_REST_Request::from_url( $request_url );
 			$response = rest_do_request( $request );
 			if ( 200 !== $response->get_status() ) {
@@ -108,7 +90,10 @@ class WSU_Syndicate_Shortcode_JSON extends WSU_Syndicate_Shortcode_Base {
 			} else {
 				$new_data = $this->process_local_posts( $response->data, $atts );
 			}
-			restore_current_blog();
+
+			if ( is_multisite() ) {
+				restore_current_blog();
+			}
 		} else {
 			error_log( 'WSUWP Content Syndicate: Remote request made. URL: ' . esc_url( $request_url ) );
 			$response = wp_remote_get( $request_url );


### PR DESCRIPTION
This clarifies the code we were using for the wsuwp_json shortcode to determine whether or not a local or remote request should be made. I've moved it to the base class so that it can become available for other shortcodes as well.

By default, "local" is used for the scheme attribute. If used in a multisite configuration, we'll always look to see if a local request can be made. "http" or "https" can be passed to override this behavior and make an external request at all times. This can be useful in multisite if a plugin or theme is enabled on that other site that adds specific functionality to a post that would not be available with `switch_to_blog()`.

In the process of clarifying this, support for single site is now provided. We had previously used `get_blog_details()`, which is a multisite specific function. There is now logic supporting single site as well.

Fixes #62.