### PR TITLE
[PR] Use per_page for events vs filter[posts_per_page]

### DIFF
--- a/includes/syndicate-shortcode-events.php
+++ b/includes/syndicate-shortcode-events.php
@@ -67,7 +67,7 @@ class WSU_Syndicate_Shortcode_Events extends WSU_Syndicate_Shortcode_Base {
 		}
 
 		if ( $atts['count'] ) {
-			$request_url = add_query_arg( array( 'filter[posts_per_page]' => absint( $atts['count'] ) ), $request_url );
+			$request_url = add_query_arg( array( 'per_page' => absint( $atts['count'] ) ), $request_url );
 		}
 
 		$response = wp_remote_get( $request_url );


### PR DESCRIPTION
I'm not sure what the upstream change is yet, but the old posts
per page filter is no longer limiting the number of events that
are pulled from the REST API.

We'll need to dig in closer to determine the root cause.