### PR TITLE
[PR] Use per_page for people vs filter[posts_per_page]

### DIFF
--- a/includes/syndicate-shortcode-people.php
+++ b/includes/syndicate-shortcode-people.php
@@ -47,7 +47,7 @@ class WSU_Syndicate_Shortcode_People extends WSU_Syndicate_Shortcode_Base {
 		$request_url = $this->build_taxonomy_filters( $atts, $request_url );
 
 		if ( $atts['count'] ) {
-			$request_url = add_query_arg( array( 'filter[posts_per_page]' => absint( $atts['count'] ) ), $request_url );
+			$request_url = add_query_arg( array( 'per_page' => absint( $atts['count'] ) ), $request_url );
 		}
 
 		$response = wp_remote_get( $request_url );


### PR DESCRIPTION
I think the same upstream change that impacted the events post
type is effecting the people post type.

@jeremyfelt #reviewmerge?