### PR TITLE
[PR] Provide a maximum value for the `per_page` query argument

### DIFF
--- a/includes/syndicate-shortcode-people.php
+++ b/includes/syndicate-shortcode-people.php
@@ -47,7 +47,8 @@ class WSU_Syndicate_Shortcode_People extends WSU_Syndicate_Shortcode_Base {
 		$request_url = $this->build_taxonomy_filters( $atts, $request_url );
 
 		if ( $atts['count'] ) {
-			$request_url = add_query_arg( array( 'filter[posts_per_page]' => absint( $atts['count'] ) ), $request_url );
+			$count = ( 100 < absint( $atts['count'] ) ) ? 100 : $atts['count'];
+			$request_url = add_query_arg( array( 'per_page' => absint( $count ) ), $request_url );
 		}
 
 		$response = wp_remote_get( $request_url );


### PR DESCRIPTION
The WP REST API expects this value to be between 0 and 100, so we'll provide
100 if the shortcode's `count` attribute happens to be greater than that :)