### PR TITLE
[PR] Treat only requests to current site as local

### DIFF
--- a/includes/syndicate-shortcode-json.php
+++ b/includes/syndicate-shortcode-json.php
@@ -77,10 +77,6 @@ class WSU_Syndicate_Shortcode_JSON extends WSU_Syndicate_Shortcode_Base {
 		$new_data = array();
 
 		if ( 'local' === $request['scheme'] ) {
-			if ( is_multisite() ) {
-				switch_to_blog( $request['site_id'] );
-			}
-
 			$request = WP_REST_Request::from_url( $request_url );
 			$response = rest_do_request( $request );
 			if ( 200 !== $response->get_status() ) {
@@ -88,12 +84,7 @@ class WSU_Syndicate_Shortcode_JSON extends WSU_Syndicate_Shortcode_Base {
 			} else {
 				$new_data = $this->process_local_posts( $response->data, $atts );
 			}
-
-			if ( is_multisite() ) {
-				restore_current_blog();
-			}
 		} else {
-			error_log( 'WSUWP Content Syndicate: Remote request made. URL: ' . esc_url( $request_url ) );
 			$response = wp_remote_get( $request_url );
 
 			if ( is_wp_error( $response ) ) {


### PR DESCRIPTION
Previously, we treated all requests to sites in the multisite install as "local" rather than making HTTP requests to retrieve content. Because of how filters are applied, any content filtering would happen in the context of the current site rather than the requested site. For the most part this does not cause an issue, but can create confusing situations when the configurations of sites start to become less alike.

Moving back to remote requests keeps things simple. :)