### PR TITLE
[PR] Update feature media support

### DIFF
--- a/includes/class-wsu-syndicate-shortcode-json.php
+++ b/includes/class-wsu-syndicate-shortcode-json.php
@@ -309,14 +309,14 @@ class WSU_Syndicate_Shortcode_JSON extends WSU_Syndicate_Shortcode_Base {
 
 			// If a featured image is assigned (int), the full data will be in the `_embedded` property.
 			if ( ! empty( $post->featured_media ) && isset( $post->_embedded->{'wp:featuredmedia'} ) && 0 < count( $post->_embedded->{'wp:featuredmedia'} ) ) {
-				$subset_feature = $post->_embedded->{'wp:featuredmedia'}[0]->media_details;
+				$subset->featured_media = $post->_embedded->{'wp:featuredmedia'}[0];
 
-				if ( isset( $subset_feature->sizes->{'post-thumbnail'} ) ) {
-					$subset->thumbnail = $subset_feature->sizes->{'post-thumbnail'}->source_url;
-				} elseif ( isset( $subset_feature->sizes->{'thumbnail'} ) ) {
-					$subset->thumbnail = $subset_feature->sizes->{'thumbnail'}->source_url;
+				if ( isset( $subset->featured_media->media_details->sizes->{'post-thumbnail'} ) ) {
+					$subset->thumbnail = $subset->featured_media->media_details->sizes->{'post-thumbnail'}->source_url;
+				} elseif ( isset( $subset->featured_media->media_details->sizes->{'thumbnail'} ) ) {
+					$subset->thumbnail = $subset->featured_media->media_details->sizes->{'thumbnail'}->source_url;
 				} else {
-					$subset->thumbnail = $post->_embedded->{'wp:featuredmedia'}[0]->source_url;
+					$subset->thumbnail = $subset->featured_media->source_url;
 				}
 			} else {
 				$subset->thumbnail = false;


### PR DESCRIPTION
This provides more data about a post's feature media to the content syndicate plugin and any custom code extending it through filters.

In making this change, we're also adjusting the format of local results. When a local REST request is made, the data is returned as an array as opposed to an object like a remote request. This causes
confusion because each use the same filter to allow the modification of response data.

This converts local results to use an object instead. It will have an impact on the [research.wsu.edu theme](https://github.com/washingtonstateuniversity/research.wsu.edu/blob/4dc7d1c724b8f9dcdaccdf99f00b84a0e2e6957b/functions.php#L78), which appears to be the only one that actually uses the array data at this point.

That theme will need to be updated at the same time as this change.