### PR TITLE
[PR] Handle `local_` prefixed shortcode attributes

### DIFF
--- a/includes/class-wsu-syndicate-shortcode-base.php
+++ b/includes/class-wsu-syndicate-shortcode-base.php
@@ -84,10 +84,26 @@ class WSU_Syndicate_Shortcode_Base {
 	 * @return array Fully populated list of attributes expected by the shortcode.
 	 */
 	public function process_attributes( $atts ) {
-		$this->defaults_atts = apply_filters( 'wsuwp_content_syndicate_default_atts', $this->defaults_atts );
+		$defaults = apply_filters( 'wsuwp_content_syndicate_default_atts', $this->defaults_atts );
 
-		$defaults = shortcode_atts( $this->defaults_atts, $this->local_default_atts );
-		$defaults = $defaults + $this->local_extended_atts;
+		$defaults = shortcode_atts( $defaults, $this->local_default_atts );
+		$defaults = array_merge( $defaults, $this->local_extended_atts );
+
+		$local_defaults = array();
+
+		// Allow for different attribute values to be passed when results from the
+		// local site are merged into results from a remote site.
+		foreach ( $defaults as $attribute => $value ) {
+
+			// The core default attributes should stay the same
+			if ( array_key_exists( $attribute, $this->defaults_atts ) ) {
+				continue;
+			}
+
+			$local_defaults[ 'local_' . $attribute ] = $value;
+		}
+
+		$defaults = array_merge( $defaults, $local_defaults );
 
 		return shortcode_atts( $defaults, $atts, $this->shortcode_name );
 	}


### PR DESCRIPTION
This extends any extended attributes so that they can be applied to results requested from the local site via `local_count`. As an example, `[wsuwp_json count=10 local_count=2 local_tag=blue]` will
pull in 2 local posts tagged as "blue" and merge them with the 10 remote results that don't have any tag restrictions. `[wsuwp_json count=10 local_count=3 tag="taco" local_tag="burrito"]` will merge local burrito posts with remote taco posts.

In refactoring for this, local results are now retrieved with a local REST request as opposed to a WP Query. This makes it easier for the data format to match as expected.