### PR TITLE
[PR] Improve caching and cache busting of local results

### DIFF
--- a/includes/content-syndicate.php
+++ b/includes/content-syndicate.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace WSU\Content_Syndicate;
+
+add_action( 'save_post_post', 'WSU\Content_Syndicate\clear_local_content_cache' );
+
+/**
+ * Clear the last changed cache for local results whenever
+ * a post is saved.
+ *
+ * @since 1.3.0
+ */
+function clear_local_content_cache() {
+	wp_cache_set( 'last_changed', microtime(), 'wsuwp-content' );
+}

--- a/includes/content-syndicate.php
+++ b/includes/content-syndicate.php
@@ -2,7 +2,33 @@
 
 namespace WSU\Content_Syndicate;
 
-add_action( 'save_post_post', 'WSU\Content_Syndicate\clear_local_content_cache' );
+add_action( 'plugins_loaded', 'WSU\Content_Syndicate\bootstrap' );
+
+/**
+ * Loads the WSUWP Content Syndicate base.
+ *
+ * @since 1.0.0
+ */
+function bootstrap() {
+	include_once __DIR__ . '/class-wsu-syndicate-shortcode-base.php';
+
+	add_action( 'init', 'WSU\Content_Syndicate\activate_shortcodes' );
+	add_action( 'save_post_post', 'WSU\Content_Syndicate\clear_local_content_cache' );
+}
+
+/**
+ * Activates the shortcodes built in with WSUWP Content Syndicate.
+ *
+ * @since 1.0.0
+ */
+function activate_shortcodes() {
+	include_once( dirname( __FILE__ ) . '/class-wsu-syndicate-shortcode-json.php' );
+
+	// Add the [wsuwp_json] shortcode to pull standard post content.
+	new \WSU_Syndicate_Shortcode_JSON();
+
+	do_action( 'wsuwp_content_syndicate_shortcodes' );
+}
 
 /**
  * Clear the last changed cache for local results whenever

--- a/wsuwp-content-syndicate.php
+++ b/wsuwp-content-syndicate.php
@@ -8,36 +8,16 @@ Author URI: https://web.wsu.edu/
 Version: 1.3.0
 */
 
-namespace WSU\ContentSyndicate;
-
 // If this file is called directly, abort.
 if ( ! defined( 'WPINC' ) ) {
 	die;
 }
 
-add_action( 'plugins_loaded', 'WSU\ContentSyndicate\bootstrap' );
-/**
- * Loads the WSUWP Content Syndicate base.
- *
- * @since 1.0.0
- */
-function bootstrap() {
-	include_once __DIR__ . '/includes/class-wsu-syndicate-shortcode-base.php';
+// This plugin uses namespaces and requires PHP 5.3 or greater.
+if ( version_compare( PHP_VERSION, '5.3', '<' ) ) {
+	add_action( 'admin_notices', create_function( '',
+		"echo '<div class=\"error\"><p>" . __( 'WSUWP Plugin Skeleton requires PHP 5.3 to function properly. Please upgrade PHP or deactivate the plugin.', 'wsuwp-plugin-skeleton' ) . "</p></div>';" ) );
+	return;
+} else {
 	include_once __DIR__ . '/includes/content-syndicate.php';
-
-	add_action( 'init', 'WSU\ContentSyndicate\activate_shortcodes' );
-}
-
-/**
- * Activates the shortcodes built in with WSUWP Content Syndicate.
- *
- * @since 1.0.0
- */
-function activate_shortcodes() {
-	include_once( dirname( __FILE__ ) . '/includes/class-wsu-syndicate-shortcode-json.php' );
-
-	// Add the [wsuwp_json] shortcode to pull standard post content.
-	new \WSU_Syndicate_Shortcode_JSON();
-
-	do_action( 'wsuwp_content_syndicate_shortcodes' );
 }

--- a/wsuwp-content-syndicate.php
+++ b/wsuwp-content-syndicate.php
@@ -3,7 +3,7 @@
 Plugin Name: WSUWP Content Syndicate
 Plugin URI: https://github.com/washingtonstateuniversity/WSUWP-Content-Syndicate
 Description: Retrieve content for display from other WordPress sites.
-Author: washingtonstateuniversity, jeremyfelt
+Author: washingtonstateuniversity, jeremyfelt, philcable
 Author URI: https://web.wsu.edu/
 Version: 1.3.0
 */
@@ -16,7 +16,7 @@ if ( ! defined( 'WPINC' ) ) {
 // This plugin uses namespaces and requires PHP 5.3 or greater.
 if ( version_compare( PHP_VERSION, '5.3', '<' ) ) {
 	add_action( 'admin_notices', create_function( '',
-		"echo '<div class=\"error\"><p>" . __( 'WSUWP Plugin Skeleton requires PHP 5.3 to function properly. Please upgrade PHP or deactivate the plugin.', 'wsuwp-plugin-skeleton' ) . "</p></div>';" ) );
+		"echo '<div class=\"error\"><p>" . __( 'WSUWP Content Syndicate requires PHP 5.3 to function properly. Please upgrade PHP or deactivate the plugin.', 'wsuwp-content-syndicate' ) . "</p></div>';" ) );
 	return;
 } else {
 	include_once __DIR__ . '/includes/content-syndicate.php';

--- a/wsuwp-content-syndicate.php
+++ b/wsuwp-content-syndicate.php
@@ -16,7 +16,7 @@ if ( ! defined( 'WPINC' ) ) {
 // This plugin uses namespaces and requires PHP 5.3 or greater.
 if ( version_compare( PHP_VERSION, '5.3', '<' ) ) {
 	add_action( 'admin_notices', create_function( '',
-		"echo '<div class=\"error\"><p>" . __( 'WSUWP Content Syndicate requires PHP 5.3 to function properly. Please upgrade PHP or deactivate the plugin.', 'wsuwp-content-syndicate' ) . "</p></div>';" ) );
+	"echo '<div class=\"error\"><p>" . __( 'WSUWP Content Syndicate requires PHP 5.3 to function properly. Please upgrade PHP or deactivate the plugin.', 'wsuwp-content-syndicate' ) . "</p></div>';" ) );
 	return;
 } else {
 	include_once __DIR__ . '/includes/content-syndicate.php';

--- a/wsuwp-content-syndicate.php
+++ b/wsuwp-content-syndicate.php
@@ -23,6 +23,7 @@ add_action( 'plugins_loaded', 'WSU\ContentSyndicate\bootstrap' );
  */
 function bootstrap() {
 	include_once __DIR__ . '/includes/class-wsu-syndicate-shortcode-base.php';
+	include_once __DIR__ . '/includes/content-syndicate.php';
 
 	add_action( 'init', 'WSU\ContentSyndicate\activate_shortcodes' );
 }


### PR DESCRIPTION
This separates how local results and remote results are cached. Rather than caching the entire shortcode display, we get a bit more granular. The processed data from each REST request (internal or external) is cached rather than the entire set of shortcode data. This allows us to clear the cache for local results whenever a post is published, updated, or trashed.