### PR TITLE
[PR] Remove old taxonomy docs

### DIFF
--- a/includes/class-wsu-syndicate-shortcode-json.php
+++ b/includes/class-wsu-syndicate-shortcode-json.php
@@ -33,9 +33,6 @@ class WSU_Syndicate_Shortcode_JSON extends WSU_Syndicate_Shortcode_Base {
 	 *                              - full           Display full content for each item.
 	 *     @type string $host                     The hostname to pull items from. Defaults to news.wsu.edu.
 	 *     @type string $site                     Overrides setting for host. Hostname and path to pull items from.
-	 *     @type string $university_category_slug The slug of a University Category from the University Taxonomy.
-	 *     @type string $site_category_slug       The slug of a Site Category. Defaults to empty.
-	 *     @type string $tag                      The slug of a tag. Defaults to empty.
 	 *     @type string $query                    Allows for a custom WP-API query. Defaults as "posts". Any
 	 *     @type int    $local_count              The number of local items to merge with the remote results.
 	 *     @type int    $count                    The number of items to pull from a feed. Defaults to the


### PR DESCRIPTION
These are now part of the WSU taxonomy extension to content syndicate.