### PR TITLE
[PR] Correct the cache key used for looking up cached results

### DIFF
--- a/includes/class-wsu-syndicate-shortcode-json.php
+++ b/includes/class-wsu-syndicate-shortcode-json.php
@@ -87,7 +87,7 @@ class WSU_Syndicate_Shortcode_JSON extends WSU_Syndicate_Shortcode_Base {
 				wp_cache_set( $cache_key, $new_data, 'wsuwp-content' );
 			}
 		} else {
-			$new_data = $this->get_content_cache( $atts, 'wsuwp-remote' );
+			$new_data = $this->get_content_cache( $atts, 'wsuwp_json' );
 
 			if ( ! is_array( $new_data ) ) {
 				$response = wp_remote_get( $request_url );


### PR DESCRIPTION
In 211a4bcf5f6832e717836d4e476417ed0d7c70cf, the cache key used to store results from remote requests was changed to be different from the cache key used to retrieve them. Since this change, no remote request has been effectively cached. 🎉 

This corrects the key to match how cache is stored.