### PR TITLE
[PR] Only request title and link when outputting headlines

### DIFF
--- a/includes/class-wsu-syndicate-shortcode-json.php
+++ b/includes/class-wsu-syndicate-shortcode-json.php
@@ -307,7 +307,7 @@ class WSU_Syndicate_Shortcode_JSON extends WSU_Syndicate_Shortcode_Base {
 			// Only a subset of data is returned for a headlines request.
 			if ( 'headlines' === $atts['output'] ) {
 				$subset->link = $post->link;
-				$subset->title   = $post->title->rendered;
+				$subset->title = $post->title->rendered;
 			} else {
 				$subset->ID = $post->id;
 				$subset->date = $post->date; // In time zone of requested site
@@ -396,7 +396,7 @@ class WSU_Syndicate_Shortcode_JSON extends WSU_Syndicate_Shortcode_Base {
 			// Only a subset of data is returned for a headlines request.
 			if ( 'headlines' === $atts['output'] ) {
 				$subset->link = $post->link;
-				$subset->title   = $post->title->rendered;
+				$subset->title = $post->title->rendered;
 			} else {
 				$subset->ID = $post->id;
 				$subset->date = $post->date; // In time zone of requested site


### PR DESCRIPTION
This helps in at least two ways:

* Reduce the size of the REST API responses by not including large blocks of content when they are not used.
* Avoid processing shortcodes unnecessarily in content that is being requested in Content Syndicate. This specifically avoids an infinite loop when the page requesting the headlines is also one of the headlines being returned.

Some weird white space changes in this, so adding w=1 to the URL may help - https://github.com/washingtonstateuniversity/WSUWP-Content-Syndicate/compare/headline-titles-only?expand=1&w=1